### PR TITLE
sprint: updates in logic for sprint 82

### DIFF
--- a/src/bin/decadog/sprint.rs
+++ b/src/bin/decadog/sprint.rs
@@ -139,7 +139,9 @@ impl<'a> MilestoneManager<'a> {
 
         let update_assignment = if issue.assignees.is_empty() {
             // If we do not have an assignee, default to updating assignment
-            Confirmation::new().with_text("Assign member?").interact()?
+            !Confirmation::new()
+                .with_text("Leave unassigned?")
+                .interact()?
         } else {
             // If we already have assignee(s), default to existing value
             !Confirmation::new()

--- a/src/core.rs
+++ b/src/core.rs
@@ -95,15 +95,7 @@ impl fmt::Display for Milestone {
 
 impl fmt::Display for Issue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(milestone) = &self.milestone {
-            write!(
-                f,
-                "{} ({}) [{}]: {}",
-                self.number, self.state, milestone.title, self.title
-            )
-        } else {
-            write!(f, "{} ({}): {}", self.number, self.state, self.title)
-        }
+        write!(f, "{}: {}", self.number, self.title)
     }
 }
 


### PR DESCRIPTION
- update `sprint start` logic to default to not assigning a user, as we don't assign users by default in `Todo`
- don't display milestone name or status alongside issue