### PR TITLE
sprint finish: remove all open issues from sprint after close

### DIFF
--- a/decadog/src/command/sprint.rs
+++ b/decadog/src/command/sprint.rs
@@ -95,7 +95,7 @@ impl<'a> MilestoneManager<'a> {
             // Otherwise, confirm the assignment
             if Confirmation::new("Assign to milestone?").interact()? {
                 self.client
-                    .assign_issue_to_milestone(&issue, &self.milestone)?;
+                    .assign_issue_to_milestone(&issue, Some(&self.milestone))?;
             } else {
                 return Ok(LoopStatus::Success);
             }
@@ -239,7 +239,7 @@ fn finish_sprint(settings: &Settings) -> Result<(), Error> {
         // If answer is no, ignore this issue
         if issue.milestone.is_none() {
             if Confirmation::new("Assign to milestone?").interact()? {
-                client.assign_issue_to_milestone(&issue, &open_milestone)?;
+                client.assign_issue_to_milestone(&issue, Some(&open_milestone))?;
             } else {
                 continue;
             }
@@ -254,12 +254,18 @@ fn finish_sprint(settings: &Settings) -> Result<(), Error> {
 
     println!();
     println!("{}", "Issues open in sprint:".bold());
-    for issue in client.get_milestone_open_issues(&open_milestone)?.iter() {
+    let open_milestone_issues = client.get_milestone_open_issues(&open_milestone)?;
+    for issue in open_milestone_issues.iter() {
         println!("{}", issue);
     }
 
+    println!();
     if Confirmation::new("Close sprint?").interact()? {
-        error!("Closing sprint not implemented.")
+        println!("Removing issues from milestone...");
+        for issue in open_milestone_issues.iter() {
+            client.assign_issue_to_milestone(&issue, None)?;
+        }
+        error!("Closing sprint not fully implemented.");
     } else {
         return Ok(());
     }

--- a/decadog_core/src/github.rs
+++ b/decadog_core/src/github.rs
@@ -153,11 +153,17 @@ impl Client {
 
     /// Get milestones by owner and repo name.
     pub fn get_milestones(&self, owner: &str, repo: &str) -> Result<Vec<Milestone>, Error> {
+        let query = GetMilestones {
+            state: None,
+            sort: None,
+            direction: Some("desc".to_owned()),
+        };
         self.request(
             Method::GET,
             self.base_url
                 .join(&format!("/repos/{}/{}/milestones", owner, repo))?,
         )?
+        .query(&query)
         .send_github()
     }
 
@@ -198,10 +204,14 @@ impl Client {
 /// Update an issue.
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 pub struct IssueUpdate {
+    /// Assign milestone. Use `None` to skip assignment, Some(None) to clear.
+    #[allow(clippy::option_option)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub milestone: Option<u32>,
+    pub milestone: Option<Option<u32>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub assignees: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,
 }
 
 /// Request to search issues.
@@ -212,6 +222,17 @@ pub struct SearchIssues {
     pub sort: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub order: Option<String>,
+}
+
+/// Request to get milestones.
+#[derive(Deserialize, Serialize, Debug, Clone, Default)]
+pub struct GetMilestones {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sort: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub direction: Option<String>,
 }
 
 /// A Github Milestone.

--- a/decadog_core/src/lib.rs
+++ b/decadog_core/src/lib.rs
@@ -141,16 +141,16 @@ impl<'a> Client<'a> {
         self.github.get_milestones(self.owner, self.repo)
     }
 
-    /// Assign an issue to a milestone.
+    /// Assign an issue to a milestone. Passing `None` will set to no milestone.
     ///
     /// This will overwrite an existing milestone, if present.
     pub fn assign_issue_to_milestone(
         &self,
         issue: &Issue,
-        milestone: &Milestone,
+        milestone: Option<&Milestone>,
     ) -> Result<Issue, Error> {
         let mut update = IssueUpdate::default();
-        update.milestone = Some(milestone.number);
+        update.milestone = Some(milestone.map(|milestone| milestone.number));
 
         self.github
             .patch_issue(&self.owner, &self.repo, issue.number, &update)


### PR DESCRIPTION
Generalises assigning a milestone to `Option<Milstone>`, where assigning `None` removes any milestone.

Do this for all open issues in the milestone after we close it.

Closes #1 