### PR TITLE
github: handle search pagination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,7 +301,7 @@ dependencies = [
  "encode_unicode 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "termios 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -468,6 +468,7 @@ dependencies = [
  "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockito 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -547,7 +548,7 @@ dependencies = [
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -981,7 +982,7 @@ dependencies = [
  "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1225,7 +1226,7 @@ dependencies = [
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1451,13 +1452,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.3.1"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1844,6 +1845,14 @@ dependencies = [
 [[package]]
 name = "thread_local"
 version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2349,7 +2358,7 @@ dependencies = [
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
-"checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
+"checksum regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b5508c1941e4e7cb19965abef075d35a9a8b5cdf0846f30b4050e9b55dc55e87"
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
@@ -2393,6 +2402,7 @@ dependencies = [
 "checksum termios 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "72b620c5ea021d75a735c943269bb07d30c9b77d6ac6b236bc8b5c496ef05625"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+"checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 "checksum tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"

--- a/decadog_core/Cargo.toml
+++ b/decadog_core/Cargo.toml
@@ -7,7 +7,9 @@ edition = "2018"
 [dependencies]
 chrono = { version = "0.4.10", features = ["serde"] }
 env_logger = "0.7.1"
+lazy_static = "1.4.0"
 log = "0.4.8"
+regex = "1.3.3"
 reqwest = "0.9.24"
 serde = "1.0.102"
 serde_derive = "1.0.102"
@@ -15,7 +17,6 @@ serde_json = "1.0.44"
 snafu = "0.6.1"
 
 [dev-dependencies]
-lazy_static = "1.4.0"
 pretty_assertions = "0.6.1"
 serde_test = "1.0.102"
 mockito = "0.22.0"

--- a/decadog_core/src/error.rs
+++ b/decadog_core/src/error.rs
@@ -26,6 +26,9 @@ pub enum Error {
 
     #[snafu(display("Url parse error: {}", source))]
     Url { source: UrlError },
+
+    #[snafu(display("Unknown error: {}", description))]
+    Unknown { description: String },
 }
 
 impl From<ReqwestError> for Error {

--- a/decadog_core/src/github/paginate.rs
+++ b/decadog_core/src/github/paginate.rs
@@ -1,0 +1,190 @@
+use std::vec::IntoIter;
+
+use log::debug;
+use reqwest::header::HeaderMap;
+use reqwest::{Client as ReqwestClient, Request, Response, Url};
+use serde::de::DeserializeOwned;
+use serde_derive::{Deserialize, Serialize};
+
+use crate::error::Error;
+
+use super::request::ResponseExt;
+
+/// A single page from the Github search API.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct GithubSearchResults<T> {
+    pub incomplete_results: bool,
+    pub items: Vec<T>,
+}
+
+/// Represents a paginated search query over some collection of items `T`.
+///
+/// Used as an iterator, the `PaginatedSearch` will continue to fetch more results
+/// until no more are available.
+pub struct PaginatedSearch<'a, T>
+where
+    Self: Sized,
+    T: DeserializeOwned,
+{
+    client: &'a ReqwestClient,
+    headers: HeaderMap,
+    page: IntoIter<T>,
+    next_page_url: Option<Url>,
+}
+
+impl<'a, T> PaginatedSearch<'a, T>
+where
+    Self: Sized,
+    T: DeserializeOwned,
+{
+    /// Create a new paginated search, and load the first page.
+    pub fn new(client: &'a ReqwestClient, initial_request: Request) -> Result<Self, Error> {
+        // The initial request is a special case
+        // Copy the headers out first to use them for auth on subsequent requests
+        let headers = initial_request.headers().clone();
+        debug!("{} {}", initial_request.method(), initial_request.url());
+        let response = client.execute(initial_request)?;
+
+        // Apply our intial response to an empty struct
+        let mut new_self = Self {
+            client,
+            headers,
+            page: vec![].into_iter(),
+            next_page_url: None,
+        };
+        new_self.apply_response(response)?;
+
+        // From this state, we can continue to generate and execute new resopnses
+        Ok(new_self)
+    }
+
+    /// Apply a response from the search API to update our state:
+    /// - store the new items to iterate throught
+    /// - extract and store the url for the next page
+    fn apply_response(&mut self, mut response: Response) -> Result<(), Error> {
+        self.next_page_url = response.next_page_url()?;
+        self.page = response
+            .from_github::<GithubSearchResults<T>>()?
+            .items
+            .into_iter();
+        Ok(())
+    }
+
+    /// Fetch the next page, and apply the response to our state.
+    fn update_page(&mut self, url: Url) -> Result<(), Error> {
+        debug!("GET {}", &url);
+        let request = self.client.get(url).headers(self.headers.clone()).build()?;
+        let response = self.client.execute(request)?;
+        self.apply_response(response)?;
+        Ok(())
+    }
+}
+
+impl<'a, T> Iterator for PaginatedSearch<'a, T>
+where
+    Self: Sized,
+    T: DeserializeOwned,
+{
+    type Item = Result<T, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.page.next() {
+            // if we still have the current page, iterate it
+            Some(item) => Some(Ok(item)),
+            // otherwise, get another page
+            None => match self.next_page_url.clone() {
+                None => None,
+                Some(url) => match self.update_page(url) {
+                    Err(e) => Some(Err(e)),
+                    Ok(_) => self.page.next().map(Ok),
+                },
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use mockito::mock;
+    use pretty_assertions::assert_eq;
+    use serde_derive::{Deserialize, Serialize};
+
+    use super::*;
+
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct TestItem {
+        data: u8,
+    }
+
+    #[test]
+    fn test_paginated_search() {
+        let page_one_path = "/url-for-page-one";
+        let page_two_path = "/url-for-page-two";
+
+        // First page should be fetched immediately
+        let client = ReqwestClient::new();
+        let initial_request = client
+            .get(&format!("{}{}", &mockito::server_url(), &page_one_path))
+            .build()
+            .unwrap();
+        let mock_page_one = mock("GET", page_one_path)
+            // return the second page url as a link
+            .with_header(
+                "link",
+                &format!(
+                    r#"<{}{}>; rel="next""#,
+                    &mockito::server_url(),
+                    &page_two_path
+                ),
+            )
+            .with_body(
+                r#"{
+  "incomplete_results": false,
+  "items": [
+    {
+      "data": 0
+    },
+    {
+      "data": 1
+    }
+  ]
+}"#,
+            )
+            .create();
+
+        let mut paginated_items =
+            PaginatedSearch::<TestItem>::new(&client, initial_request).unwrap();
+
+        mock_page_one.assert();
+        assert_eq!(
+            paginated_items.next().unwrap().unwrap(),
+            TestItem { data: 0 }
+        );
+        assert_eq!(
+            paginated_items.next().unwrap().unwrap(),
+            TestItem { data: 1 }
+        );
+
+        // When we run out of items, we should fetch the next page
+        let mock_page_two = mock("GET", page_two_path)
+            .with_body(
+                r#"{
+  "incomplete_results": false,
+  "items": [
+    {
+      "data": 2
+    }
+  ]
+}"#,
+            )
+            .create();
+        assert_eq!(
+            paginated_items.next().unwrap().unwrap(),
+            TestItem { data: 2 }
+        );
+        mock_page_two.assert();
+
+        // As the last page didn't have a link, the next issue should be None
+        assert!(paginated_items.next().is_none());
+    }
+}

--- a/decadog_core/src/github/request.rs
+++ b/decadog_core/src/github/request.rs
@@ -1,0 +1,79 @@
+use lazy_static::lazy_static;
+use regex::Regex;
+use reqwest::header::LINK;
+use reqwest::{RequestBuilder, Response, Url};
+use serde::de::DeserializeOwned;
+
+use crate::error::Error;
+
+lazy_static! {
+    static ref RX_LINK_NEXT: Regex =
+        Regex::new(r#"<(?P<url>[^>]+)>;[^,]* rel="next""#).expect("Invalid link regex.");
+}
+
+/// Interpret a response with potential JSON errors from the Github API.
+pub trait ResponseExt {
+    fn from_github<T>(&mut self) -> Result<T, Error>
+    where
+        Self: Sized,
+        T: DeserializeOwned;
+
+    fn next_page_url(&self) -> Result<Option<Url>, Error>;
+}
+
+impl ResponseExt for Response {
+    fn from_github<T>(&mut self) -> Result<T, Error>
+    where
+        Self: Sized,
+        T: DeserializeOwned,
+    {
+        let status = self.status();
+        if status.is_success() {
+            Ok(self.json()?)
+        } else if status.is_client_error() {
+            Err(Error::Github {
+                error: self.json()?,
+                status,
+            })
+        } else {
+            Err(Error::Api {
+                description: "Unexpected response status code.".to_owned(),
+                status,
+            })
+        }
+    }
+
+    fn next_page_url(&self) -> Result<Option<Url>, Error> {
+        // TODO(tommilligan) Find an actual Link header parsing implementation
+        match self.headers().get(LINK) {
+            None => Ok(None),
+            Some(header_value) => {
+                match RX_LINK_NEXT.captures(header_value.to_str().map_err(|_| Error::Unknown {
+                    description: "Expected Github Link header to be valid.".to_owned(),
+                })?) {
+                    None => Ok(None),
+                    Some(captured_groups) => Ok(Some(Url::parse(&captured_groups["url"])?)),
+                }
+            }
+        }
+    }
+}
+
+/// Send a HTTP request to Github, and return the resulting struct.
+pub trait RequestBuilderExt {
+    fn send_github<T>(self) -> Result<T, Error>
+    where
+        Self: Sized,
+        T: DeserializeOwned;
+}
+
+impl RequestBuilderExt for RequestBuilder {
+    fn send_github<T>(self) -> Result<T, Error>
+    where
+        Self: Sized,
+        T: DeserializeOwned,
+    {
+        let mut response = self.send()?;
+        response.from_github()
+    }
+}

--- a/decadog_core/src/lib.rs
+++ b/decadog_core/src/lib.rs
@@ -15,8 +15,8 @@ pub mod zenhub;
 pub use crate::core::{AssignedTo, Sprint};
 pub use error::Error;
 use github::{
-    Direction, Issue, IssueUpdate, Milestone, MilestoneUpdate, OrganisationMember, Repository,
-    SearchIssues,
+    paginate::PaginatedSearch, Direction, Issue, IssueUpdate, Milestone, MilestoneUpdate,
+    OrganisationMember, Repository, SearchIssues,
 };
 use zenhub::{Board, Pipeline, PipelinePosition, StartDate};
 
@@ -178,7 +178,7 @@ impl<'a> Client<'a> {
     pub fn get_issues_closed_after(
         &self,
         datetime: &DateTime<FixedOffset>,
-    ) -> Result<Vec<Issue>, Error> {
+    ) -> Result<PaginatedSearch<Issue>, Error> {
         let query = SearchIssues {
             q: format!(
                 "repo:{}/{} type:issue state:closed closed:>={}",
@@ -194,7 +194,10 @@ impl<'a> Client<'a> {
     }
 
     /// Get issues in a given milestone.
-    pub fn get_milestone_issues(&self, milestone: &Milestone) -> Result<Vec<Issue>, Error> {
+    pub fn get_milestone_issues(
+        &self,
+        milestone: &Milestone,
+    ) -> Result<PaginatedSearch<Issue>, Error> {
         let query = SearchIssues {
             q: format!(
                 r#"repo:{}/{} type:issue milestone:"{}""#,
@@ -208,7 +211,10 @@ impl<'a> Client<'a> {
     }
 
     /// Get issues open in a given milestone.
-    pub fn get_milestone_open_issues(&self, milestone: &Milestone) -> Result<Vec<Issue>, Error> {
+    pub fn get_milestone_open_issues(
+        &self,
+        milestone: &Milestone,
+    ) -> Result<PaginatedSearch<Issue>, Error> {
         let query = SearchIssues {
             q: format!(
                 r#"repo:{}/{} type:issue state:open milestone:"{}""#,
@@ -275,6 +281,8 @@ mod tests {
                 &FixedOffset::east(0)
                     .from_utc_datetime(&NaiveDate::from_ymd(2011, 4, 22).and_hms(13, 33, 48)),
             )
+            .unwrap()
+            .collect::<Result<Vec<Issue>, _>>()
             .unwrap();
 
         mock.assert();
@@ -303,6 +311,8 @@ mod tests {
                 due_on: FixedOffset::east(0)
                     .from_utc_datetime(&NaiveDate::from_ymd(2011, 4, 22).and_hms(13, 33, 48)),
             })
+            .unwrap()
+            .collect::<Result<Vec<Issue>, _>>()
             .unwrap();
 
         mock.assert();


### PR DESCRIPTION
- move `SendGithubExt` to `request::RequestBuilderExt`
- implement `ResponseExt` to parse `Link` header on Github responses as described [here](https://developer.github.com/v3/guides/traversing-with-pagination/)
- implement `PaginatedSearch` as an [Iterator](https://doc.rust-lang.org/rust-by-example/trait/iter.html) that knows how to further pages of results

Closes #38 