### PR TITLE
zenhub: make client workspace aware

### DIFF
--- a/decadog_core/src/lib.rs
+++ b/decadog_core/src/lib.rs
@@ -18,7 +18,7 @@ use github::{
     paginate::PaginatedSearch, Direction, Issue, IssueUpdate, Milestone, MilestoneUpdate,
     OrganisationMember, Repository, SearchIssues, State,
 };
-use zenhub::{Board, Pipeline, PipelinePosition, StartDate};
+use zenhub::{Board, Pipeline, PipelinePosition, StartDate, Workspace};
 
 /// Decadog client, used to abstract complex tasks over several APIs.
 pub struct Client<'a> {
@@ -77,9 +77,18 @@ impl<'a> Client<'a> {
         self.zenhub.get_start_date(repository.id, milestone.number)
     }
 
+    /// Get Zenhub first workspace for a repository.
+    pub fn get_first_workspace(&self, repository: &Repository) -> Result<Workspace, Error> {
+        self.zenhub.get_first_workspace(repository.id)
+    }
+
     /// Get Zenhub board for a repository.
-    pub fn get_board(&self, repository: &Repository) -> Result<Board, Error> {
-        self.zenhub.get_board(repository.id)
+    pub fn get_board(
+        &self,
+        repository: &Repository,
+        workspace: &Workspace,
+    ) -> Result<Board, Error> {
+        self.zenhub.get_board(repository.id, &workspace.id)
     }
 
     /// Get Zenhub issue metadata.
@@ -145,6 +154,7 @@ impl<'a> Client<'a> {
     pub fn move_issue_to_pipeline(
         &self,
         repository: &Repository,
+        workspace: &Workspace,
         issue: &Issue,
         pipeline: &Pipeline,
     ) -> Result<(), Error> {
@@ -152,7 +162,7 @@ impl<'a> Client<'a> {
         position.pipeline_id = pipeline.id.clone();
 
         self.zenhub
-            .move_issue(repository.id, issue.number, &position)
+            .move_issue(repository.id, &workspace.id, issue.number, &position)
     }
 
     /// Get a repository from the API.

--- a/decadog_core/src/zenhub.rs
+++ b/decadog_core/src/zenhub.rs
@@ -126,6 +126,26 @@ impl Client {
             .headers(self.headers.clone())
     }
 
+    /// Get the first Zenhub workspace for a repository.
+    pub fn get_first_workspace(&self, repository_id: u64) -> Result<Workspace, Error> {
+        self.get_workspaces(repository_id)?
+            .into_iter()
+            .nth(0)
+            .ok_or_else(|| Error::Unknown {
+                description: "No Zenhub workspace found for repository.".to_owned(),
+            })
+    }
+
+    /// Get Zenhub workspaces for a repository.
+    pub fn get_workspaces(&self, repository_id: u64) -> Result<Vec<Workspace>, Error> {
+        self.request(
+            Method::GET,
+            self.base_url
+                .join(&format!("/p2/repositories/{}/workspaces", repository_id))?,
+        )
+        .send_api()
+    }
+
     /// Get Zenhub board for a repository.
     pub fn get_board(&self, repository_id: u64) -> Result<Board, Error> {
         self.request(
@@ -217,6 +237,15 @@ impl Client {
         .json(position)
         .send_api_no_response()
     }
+}
+
+/// Zenhub Workspace.
+#[derive(Deserialize, Serialize, Debug, Clone, Default, PartialEq)]
+pub struct Workspace {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub id: String,
+    pub repositories: Vec<u64>,
 }
 
 /// Zenhub issue data.

--- a/decadog_core/src/zenhub.rs
+++ b/decadog_core/src/zenhub.rs
@@ -147,11 +147,13 @@ impl Client {
     }
 
     /// Get Zenhub board for a repository.
-    pub fn get_board(&self, repository_id: u64) -> Result<Board, Error> {
+    pub fn get_board(&self, repository_id: u64, workspace_id: &str) -> Result<Board, Error> {
         self.request(
             Method::GET,
-            self.base_url
-                .join(&format!("/p1/repositories/{}/board", repository_id))?,
+            self.base_url.join(&format!(
+                "/p2/workspaces/{}/repositories/{}/board",
+                workspace_id, repository_id
+            ))?,
         )
         .send_api()
     }
@@ -224,14 +226,15 @@ impl Client {
     pub fn move_issue(
         &self,
         repository_id: u64,
+        workspace_id: &str,
         issue_number: u32,
         position: &PipelinePosition,
     ) -> Result<(), Error> {
         self.request(
             Method::POST,
             self.base_url.join(&format!(
-                "/p1/repositories/{}/issues/{}/moves",
-                repository_id, issue_number
+                "/p2/workspaces/{}/repositories/{}/issues/{}/moves",
+                workspace_id, repository_id, issue_number
             ))?,
         )
         .json(position)
@@ -291,7 +294,6 @@ pub struct PipelineIssue {
     pub issue_number: u32,
     pub estimate: Option<Estimate>,
     pub is_epic: bool,
-    pub position: u32,
 }
 
 /// A Zenhub pipeline.


### PR DESCRIPTION
Zenhub supports multiple workspaces per repo. This PR upgrades the client to be workspace aware, which is required for more recent API routes.

We still pick the default workspace without user input.