### PR TITLE
finish: fix issues collected for review

### DIFF
--- a/decadog_core/src/github/mod.rs
+++ b/decadog_core/src/github/mod.rs
@@ -293,6 +293,10 @@ impl SearchQueryBuilder {
         self.term(&format!(r#"milestone:"{}""#, milestone_title))
     }
 
+    pub fn no_milestone(&mut self) -> &mut Self {
+        self.key_value("no", "milestone")
+    }
+
     pub fn closed_on_or_after<Tz: TimeZone>(&mut self, datetime: &DateTime<Tz>) -> &mut Self
     where
         Tz::Offset: fmt::Display,


### PR DESCRIPTION
Instead of trying to collect all the issues for review in one go, collect them as two disjoint sets:
  - out of sprint tickets closed in the last two weeks
  - all issues in the milestone already closed